### PR TITLE
Develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "ghost-theme-ectoplasm",
     "description": "A clean, minimal default theme for the Ghost publishing platform (fork of Casper)",
     "demo": "https://demo.ghost.io",
-    "version": "3.0.13-0.1.0",
+    "version": "3.0.13-0.1.1",
     "engines": {
         "ghost": ">=3.0.0",
         "ghost-api": "v3"

--- a/post.hbs
+++ b/post.hbs
@@ -118,7 +118,7 @@ into the {body} of the default.hbs template --}}
             <section class="post-full-comments">
                 <div id="disqus_thread"
                     data-page-url="{{url absolute="true"}}"
-                    data-page-identifier="ghost-{{comment_id}}"
+                    data-page-identifier="{{comment_id}}"
                 >
                 </div>
             </section>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5338,9 +5338,9 @@ websocket-driver@>=0.5.1:
     websocket-extensions ">=0.1.1"
 
 websocket-extensions@>=0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
-  integrity sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
+  integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
 
 which-module@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
* [83be21a](https://github.com/OnlyThePixel/ghost-theme-ectoplasm/commit/83be21a) refactor(comment): remove ghost prefix from disqus page identifiers - Alberto Fernandez
* [92d021c](https://github.com/OnlyThePixel/ghost-theme-ectoplasm/commit/92d021c) Bump websocket-extensions from 0.1.3 to 0.1.4 - dependabot[bot]